### PR TITLE
Fix issue when there are more than one compute instances in the state

### DIFF
--- a/add_vheads.sh
+++ b/add_vheads.sh
@@ -13,7 +13,7 @@ usage() {
 Usage:
 Parameters:
   -n number of enode instances (cluster size): eg 3
-  -a use public ip (true=1/false=0)
+  -a IP address
 Examples:
   ./add_vheads.sh -n 2 -a 1
 E_O_F
@@ -38,17 +38,10 @@ while getopts "h?:n:a:" opt; do
         ;;
     n)  NUM_OF_VMS=${OPTARG}
         ;;
-    a)  USE_PUBLIC_IP=${OPTARG}
+    a)  EMS_ADDRESS=${OPTARG}
         ;;
     esac
 done
-
-#capture computed variables
-if [[ ${USE_PUBLIC_IP} -eq 1 ]]; then
-  EMS_ADDRESS=`terraform show | grep assigned_nat_ip | cut -d " " -f 5`
-else
-  EMS_ADDRESS=`terraform show | grep network_ip | cut -d " " -f 5`
-fi
 
 #capture computed variables
 echo "EMS_ADDRESS: ${EMS_ADDRESS}" | tee ${LOG}

--- a/create_google_ilb.sh
+++ b/create_google_ilb.sh
@@ -48,6 +48,8 @@ echo "ZONE: $ZONE" | tee -a ${LOG}
 echo "NETWORK: $NETWORK" | tee -a ${LOG}
 echo "SUBNETWORK: $SUBNETWORK" | tee -a ${LOG}
 echo "CLUSTER_NAME: $CLUSTER_NAME" | tee -a ${LOG}
+echo "SERVICE_EMAIL: $SERVICE_EMAIL" | tee -a ${LOG}
+echo "PROJECT: $PROJECT" | tee -a ${LOG}
 #set -x
 
 # Configure Google Internal Load Balancer

--- a/create_vheads.sh
+++ b/create_vheads.sh
@@ -24,7 +24,8 @@ Usage:
   -n number of vhead instances (cluster size): eg 3
   -d disk config: eg 8_375
   -v vm config: eg 4_42
-  -p use public IP: "true" "false"
+  -p IP address
+  -r cluster name
   -s deployment type: "single" "dual" "multizone"
   -a availability zones
   -e company name
@@ -51,7 +52,7 @@ LOG="create_vheads.log"
 #LOG=/dev/null
 #DISK_SIZE=
 
-while getopts "h?:c:l:t:n:d:v:p:s:a:e:f:g:i:k:j:b:" opt; do
+while getopts "h?:c:l:t:n:d:v:p:s:a:e:f:g:i:k:j:b:r:" opt; do
     case "$opt" in
     h|\?)
         usage
@@ -72,7 +73,7 @@ while getopts "h?:c:l:t:n:d:v:p:s:a:e:f:g:i:k:j:b:" opt; do
         ;;
     v)  VM_CONFIG=${OPTARG}
         ;;
-    p)  USE_PUBLIC_IP=${OPTARG}
+    p)  EMS_ADDRESS=${OPTARG}
         ;;
     s)  DEPLOYMENT_TYPE=${OPTARG}
         ;;
@@ -92,17 +93,13 @@ while getopts "h?:c:l:t:n:d:v:p:s:a:e:f:g:i:k:j:b:" opt; do
 	      ;;
     b)  DATA_CONTAINER=${OPTARG}
         ;;
+    r)  EMS_NAME=${OPTARG}
+        ;;
     esac
 done
 
 #capture computed variables
-EMS_NAME=`terraform show | grep reference_name | cut -d " " -f 5`
 EMS_HOSTNAME="${EMS_NAME}.local"
-if [[ $USE_PUBLIC_IP -eq 1 ]]; then
-  EMS_ADDRESS=`terraform show | grep 0.nat_ip | cut -d " " -f 5`
-else
-  EMS_ADDRESS=`terraform show | grep network_ip | cut -d " " -f 5`
-fi
 
 # load balancer mode
 if [[ $LB == "elastifile" ]]; then

--- a/destroy_google_ilb.sh
+++ b/destroy_google_ilb.sh
@@ -44,13 +44,7 @@ while getopts "h?:z:n:s:c:a:e:p:" opt; do
 done
 
 #capture computed variables
-EMS_NAME=`terraform show | grep reference_name | cut -d " " -f 5`
-EMS_HOSTNAME="${EMS_NAME}.local"
-#if [[ $USE_PUBLIC_IP -eq 1 ]]; then
-#  EMS_ADDRESS=`terraform show | grep assigned_nat_ip | cut -d " " -f 5`
-#else
-#  EMS_ADDRESS=`terraform show | grep network_ip | cut -d " " -f 5`
-#fi
+EMS_HOSTNAME="${CLUSTER_NAME}.local"
 REGION=`echo $ZONE | awk -F- '{print $1"-"$2 }'`
 
 echo "REGION: $REGION" | tee ${LOG}

--- a/google_ecfs.tf
+++ b/google_ecfs.tf
@@ -214,9 +214,15 @@ SCRIPT
   }
 }
 
+locals {
+  public_ip = "${element(concat(google_compute_instance.Elastifile-EMS-Public.*.network_interface.0.access_config.0.assigned_nat_ip, list("")), 0)}"
+  private_ip = "${element(concat(google_compute_instance.Elastifile-EMS-Private.*.network_interface.0.network_ip , list("")), 0)}"
+  ems_address = "${var.USE_PUBLIC_IP ? local.public_ip : local.private_ip}"
+}
+
 resource "null_resource" "cluster" {
   provisioner "local-exec" {
-    command     = "${path.module}/create_vheads.sh -c ${var.TEMPLATE_TYPE} -l ${var.LB_TYPE} -t ${var.DISK_TYPE} -n ${var.NUM_OF_VMS} -d ${var.DISK_CONFIG} -v ${var.VM_CONFIG} -p ${var.USE_PUBLIC_IP} -s ${var.DEPLOYMENT_TYPE} -a ${var.NODES_ZONES} -e ${var.COMPANY_NAME} -f ${var.CONTACT_PERSON_NAME} -g ${var.EMAIL_ADDRESS} -i ${var.ILM} -k ${var.ASYNC_DR} -j ${var.LB_VIP} -b ${var.DATA_CONTAINER}"
+    command     = "${path.module}/create_vheads.sh -c ${var.TEMPLATE_TYPE} -l ${var.LB_TYPE} -t ${var.DISK_TYPE} -n ${var.NUM_OF_VMS} -d ${var.DISK_CONFIG} -v ${var.VM_CONFIG} -p ${local.ems_address} -r ${var.CLUSTER_NAME} -s ${var.DEPLOYMENT_TYPE} -a ${var.NODES_ZONES} -e ${var.COMPANY_NAME} -f ${var.CONTACT_PERSON_NAME} -g ${var.EMAIL_ADDRESS} -i ${var.ILM} -k ${var.ASYNC_DR} -j ${var.LB_VIP} -b ${var.DATA_CONTAINER}"
     interpreter = ["/bin/bash", "-c"]
   }
 
@@ -254,7 +260,7 @@ resource "null_resource" "update_cluster" {
   }
 
   provisioner "local-exec" {
-    command     = "${path.module}/update_vheads.sh -n ${var.NUM_OF_VMS} -a ${var.USE_PUBLIC_IP} -l ${var.LB_TYPE} -e ${var.SERVICE_EMAIL} -p ${var.PROJECT}"
+    command     = "${path.module}/update_vheads.sh -n ${var.NUM_OF_VMS} -a ${local.ems_address} -r ${var.CLUSTER_NAME} -l ${var.LB_TYPE} -e ${var.SERVICE_EMAIL} -p ${var.PROJECT}"
     interpreter = ["/bin/bash", "-c"]
   }
 

--- a/remove_vheads.sh
+++ b/remove_vheads.sh
@@ -13,7 +13,7 @@ usage() {
 Usage:
 Parameters:
   -n number of enode instances (cluster size): eg 3
-  -a use public ip (true=1/false=0)
+  -a IP address
 Examples:
   ./remove_vheads.sh -n 2 -a 1
 E_O_F
@@ -38,17 +38,10 @@ while getopts "h?:n:a:" opt; do
         ;;
     n)  NUM_OF_VMS=${OPTARG}
         ;;
-    a)  USE_PUBLIC_IP=${OPTARG}
+    a)  EMS_ADDRESS=${OPTARG}
         ;;
     esac
 done
-
-#capture computed variables
-if [[ ${USE_PUBLIC_IP} -eq 1 ]]; then
-  EMS_ADDRESS=`terraform show | grep assigned_nat_ip | cut -d " " -f 5`
-else
-  EMS_ADDRESS=`terraform show | grep network_ip | cut -d " " -f 5`
-fi
 
 echo "EMS_ADDRESS: ${EMS_ADDRESS}" | tee ${LOG}
 echo "NUM_OF_VMS: ${NUM_OF_VMS}" | tee -a ${LOG}

--- a/update_google_ilb.sh
+++ b/update_google_ilb.sh
@@ -9,6 +9,7 @@ Usage:
   -a list of node ips
   -e service email
   -p project
+  -r cluster name
   example: update_google_ilb.sh -a 10.0.0.1,10.0.0.2 -e <service account> -p <project id>
 E_O_F
   exit 1
@@ -16,8 +17,7 @@ E_O_F
 
 #variables
 LOG="update_google_ilb.log"
-CLUSTER_NAME=`terraform show | grep reference_name | cut -d " " -f 5`
-while getopts "h?:a:e:p:" opt; do
+while getopts "h?:a:e:p:r:" opt; do
     case "$opt" in
     h|\?)
         usage
@@ -28,6 +28,8 @@ while getopts "h?:a:e:p:" opt; do
     e)  SERVICE_EMAIL=${OPTARG}
         ;;
     p)  PROJECT=${OPTARG}
+        ;;
+    r)  CLUSTER_NAME=${OPTARG}
         ;;
     esac
 done

--- a/update_vheads.sh
+++ b/update_vheads.sh
@@ -12,7 +12,7 @@ usage() {
 Usage:
 Parameters:
   -n number of enode instances (cluster size): eg 3
-  -a use public ip (true=1/false=0)
+  -a IP address
   -l lb type
   -e service email
   -p project
@@ -27,7 +27,7 @@ SESSION_FILE=session.txt
 PASSWORD=`cat password.txt | cut -d " " -f 1`
 LOG="update_vheads.log"
 
-while getopts "h?:n:a:l:e:p:" opt; do
+while getopts "h?:n:a:l:e:p:r:" opt; do
     case "$opt" in
     h|\?)
         usage
@@ -35,22 +35,18 @@ while getopts "h?:n:a:l:e:p:" opt; do
         ;;
     n)  NUM_OF_VMS=${OPTARG}
         ;;
-    a)  USE_PUBLIC_IP=${OPTARG}
+    a)  EMS_ADDRESS=${OPTARG}
         ;;
     l)  LB_TYPE=${OPTARG}
         ;;
     e)  SERVICE_EMAIL=${OPTARG}
         ;;
     p)  PROJECT=${OPTARG}
+        ;;
+    r)  CLUSTER_NAME=${OPTARG}
+        ;;
     esac
 done
-
-#capture computed variables
-if [[ ${USE_PUBLIC_IP} -eq 1 ]]; then
-  EMS_ADDRESS=`terraform show | grep assigned_nat_ip | cut -d " " -f 5`
-else
-  EMS_ADDRESS=`terraform show | grep network_ip | cut -d " " -f 5`
-fi
 
 #capture computed variables
 echo "EMS_ADDRESS: ${EMS_ADDRESS}" | tee ${LOG}
@@ -68,7 +64,7 @@ function update_vheads {
   echo "PRE_NUM_OF_VMS: ${PRE_NUM_OF_VMS}" | tee -a ${LOG}
   if [[ ${NUM_OF_VMS} > ${PRE_NUM_OF_VMS} ]]; then
     let NUM=${NUM_OF_VMS}-${PRE_NUM_OF_VMS}
-    ./add_vheads.sh -n $NUM -a $USE_PUBLIC_IP
+    ./add_vheads.sh -n $NUM -a $EMS_ADDRESS
      if [[ $LB_TYPE == "google" ]]; then
         POST_IPS=$(curl -k -b ./session.txt -H "Content-Type: application/json" https://${EMS_ADDRESS}/api/enodes/ 2> /dev/null | jsonValue external_ip | sed s'/[,]$//')
         ADDED_IPS=""
@@ -80,11 +76,11 @@ function update_vheads {
         done
         ADDED_IPS=$(echo $ADDED_IPS | sed s'/[,]//')
         echo "ADDED_IPS: ${ADDED_IPS}" | tee ${LOG}    
-        ./update_google_ilb.sh -a $ADDED_IPS -e $SERVICE_EMAIL -p $PROJECT
+        ./update_google_ilb.sh -a $ADDED_IPS -e $SERVICE_EMAIL -p $PROJECT -r $CLUSTER_NAME
       fi
   else
     let NUM=${PRE_NUM_OF_VMS}-${NUM_OF_VMS}
-    ./remove_vheads.sh -n $NUM -a $USE_PUBLIC_IP
+    ./remove_vheads.sh -n $NUM -a $EMS_ADDRESS
 fi
 }
 


### PR DESCRIPTION
Trying to use `terraform show` along with `grep` is very brittle and doesn't work when the scripts are used as a module in another terraform project. These set of changes fixes that by passing the values directly as parameters to the script.

IP address selection between public and private instances is tricky one and uses a well known terraform hack to avoid referring to the disabled compute instance. 

