### PR TITLE
Allow EMS resolved IP to be public or private

### DIFF
--- a/efaas-automation/google_efaas.tf
+++ b/efaas-automation/google_efaas.tf
@@ -1,4 +1,3 @@
-
 variable "EFAAS_END_POINT" {
   default = "https://golden-eagle.gcp.elastifile.com"
 }
@@ -77,10 +76,9 @@ variable "HARD_QUOTA" {
   default = "0"
 }
 
-
 resource "null_resource" "instance" {
   provisioner "local-exec" {
-    command	 = "${path.module}/create_efaas.sh -a ${var.EFAAS_END_POINT} -b ${var.PROJECT} -c ${var.NAME} -d ${var.DESCRIPTION} -e ${var.REGION} -f ${var.ZONE} -g ${var.SERVICE_CLASS} -i ${var.NETWORK} -j ${var.ACL_RANGE} -k ${var.ACL_ACCESS_RIGHTS} -l ${var.SNAPSHOT} -m ${var.SNAPSHOT_SCHEDULER} -n ${var.SNAPSHOT_RETENTION} -o ${var.CAPACITY} -p ${var.CREDENTIALS} -q ${var.DC} -r ${var.DC_DESCRIPTION} -s ${var.QUOTA_TYPE} -t ${var.HARD_QUOTA}"
+    command = "${path.module}/create_efaas.sh -a ${var.EFAAS_END_POINT} -b ${var.PROJECT} -c ${var.NAME} -d ${var.DESCRIPTION} -e ${var.REGION} -f ${var.ZONE} -g ${var.SERVICE_CLASS} -i ${var.NETWORK} -j ${var.ACL_RANGE} -k ${var.ACL_ACCESS_RIGHTS} -l ${var.SNAPSHOT} -m ${var.SNAPSHOT_SCHEDULER} -n ${var.SNAPSHOT_RETENTION} -o ${var.CAPACITY} -p ${var.CREDENTIALS} -q ${var.DC} -r ${var.DC_DESCRIPTION} -s ${var.QUOTA_TYPE} -t ${var.HARD_QUOTA}"
 
     interpreter = ["/bin/bash", "-c"]
   }
@@ -96,19 +94,20 @@ resource "null_resource" "update_dc" {
   count = "${var.ACTION == "Update_filesystem" ? 1 : 0}"
 
   triggers {
-    range = "${var.ACL_RANGE}"
+    range        = "${var.ACL_RANGE}"
     accessrights = "${var.ACL_ACCESS_RIGHTS}"
-    snapshot = "${var.SNAPSHOT}"
-    schedule = "${var.SNAPSHOT_SCHEDULER}"
-    retention = "${var.SNAPSHOT_RETENTION}"
-    quotatype = "${var.QUOTA_TYPE}"
-    hardquota = "${var.HARD_QUOTA}"
+    snapshot     = "${var.SNAPSHOT}"
+    schedule     = "${var.SNAPSHOT_SCHEDULER}"
+    retention    = "${var.SNAPSHOT_RETENTION}"
+    quotatype    = "${var.QUOTA_TYPE}"
+    hardquota    = "${var.HARD_QUOTA}"
   }
- 
+
   provisioner "local-exec" {
     command     = "${path.module}/update_dc.sh -a ${var.EFAAS_END_POINT} -b ${var.PROJECT} -c ${var.NAME} -d ${var.ACL_RANGE} -e ${var.CREDENTIALS} -f ${var.ACL_ACCESS_RIGHTS} -g ${var.DC} -i ${var.SNAPSHOT} -j ${var.SNAPSHOT_SCHEDULER} -k ${var.SNAPSHOT_RETENTION} -l ${var.QUOTA_TYPE} -m ${var.HARD_QUOTA}"
     interpreter = ["/bin/bash", "-c"]
   }
+
   depends_on = ["null_resource.instance"]
 }
 
@@ -123,6 +122,7 @@ resource "null_resource" "update_instance" {
     command     = "${path.module}/update_efaas.sh -a ${var.EFAAS_END_POINT} -b ${var.PROJECT} -c ${var.NAME} -d ${var.CAPACITY} -e ${var.CREDENTIALS} -f ${var.SERVICE_CLASS}"
     interpreter = ["/bin/bash", "-c"]
   }
+
   depends_on = ["null_resource.instance"]
 }
 
@@ -137,6 +137,7 @@ resource "null_resource" "add_dc" {
     command     = "${path.module}/add_dc.sh -a ${var.EFAAS_END_POINT} -b ${var.PROJECT} -c ${var.NAME} -d ${var.CREDENTIALS} -e ${var.DC} -f ${var.DC_DESCRIPTION} -g ${var.QUOTA_TYPE} -i ${var.HARD_QUOTA} -j ${var.SNAPSHOT} -k ${var.SNAPSHOT_SCHEDULER} -l ${var.SNAPSHOT_RETENTION} -m ${var.ACL_RANGE} -n ${var.ACL_ACCESS_RIGHTS}"
     interpreter = ["/bin/bash", "-c"]
   }
+
   depends_on = ["null_resource.instance"]
 }
 
@@ -151,5 +152,6 @@ resource "null_resource" "delete_dc" {
     command     = "${path.module}/delete_dc.sh -a ${var.EFAAS_END_POINT} -b ${var.PROJECT} -c ${var.NAME} -d ${var.CREDENTIALS} -e ${var.DC}"
     interpreter = ["/bin/bash", "-c"]
   }
+
   depends_on = ["null_resource.instance"]
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -31,7 +31,10 @@ NETWORK = "elastifile-network"
 # GCP service account credential filename
 CREDENTIALS = "booming-mission-107807-0e99db2e1ce2.json"
 SERVICE_EMAIL = "cloud-performance@booming-mission-107807.iam.gserviceaccount.com"
-# true false
+# Whether to create an EMS with a public IP address. true/false
+CREATE_PUBLIC_IP = true
+# Whether to access the EMS (from the machine running terraform) via public or
+# private IP. Only relevant when CREATE_PUBLIC_IP is true. true/false
 USE_PUBLIC_IP = true
 # deployment type - single, dual, multizone
 DEPLOYMENT_TYPE = "single"


### PR DESCRIPTION
It is useful to be able to access the EMS by its private IP address even when the EMS itself has a public IP address. For example, when organization policies prevent opening ports on the public IP.